### PR TITLE
#54 Buyer should be able to get a single product

### DIFF
--- a/src/__test__/buyerController.test.ts
+++ b/src/__test__/buyerController.test.ts
@@ -1,0 +1,75 @@
+import request from 'supertest';
+import app from '../app';
+import {
+  afterAllHook,
+  beforeAllHook,
+  getBuyerToken,
+  getVendorToken,
+} from './testSetup';
+beforeAll(beforeAllHook);
+afterAll(afterAllHook);
+
+describe('Buyer Controller test', () => {
+  let buyerToken: string;
+  let vendorToken: string;
+  let productId: number;
+  let categoryId: number;
+
+  beforeAll(async () => {
+    buyerToken = await getBuyerToken();
+    vendorToken = await getVendorToken();
+  });
+
+  it('should get a product by id', async () => {
+    // create a category
+    const categoryData = {
+      name: 'Category4',
+      description: 'category description',
+    };
+
+    const categoryResponse = await request(app)
+      .post('/api/v1/category')
+      .set('Authorization', `Bearer ${vendorToken}`)
+      .send(categoryData);
+
+    categoryId = categoryResponse.body.data.id;
+
+    const productData = {
+      name: 'New Product Two',
+      image: 'new_product.jpg',
+      gallery: [],
+      shortDesc: 'This is a new product',
+      longDesc: 'Detailed description of the new product',
+      categoryId: categoryId,
+      quantity: 10,
+      regularPrice: 5,
+      salesPrice: 4,
+      tags: ['tag1', 'tag2'],
+      type: 'Simple',
+      isAvailable: true,
+    };
+
+    const response = await request(app)
+      .post('/api/v1/product')
+      .set('Authorization', `Bearer ${vendorToken}`)
+      .send(productData);
+
+    productId = response.body.data.id;
+
+    const getResponse = await request(app)
+      .get(`/api/v1/buyer/get_product/${productId}`)
+      .set('Authorization', `Bearer ${buyerToken}`);
+
+
+    expect(getResponse.statusCode).toEqual(200);
+    expect(getResponse.body.msg).toEqual('Product retrieved successfully');
+  });
+
+  it('should return a 404 if product is not found', async () => {
+    const response = await request(app)
+      .get('/api/v1/buyer/get_product/5')
+      .set('Authorization', `Bearer ${buyerToken}`);
+    expect(response.status).toBe(404);
+    expect(response.body.msg).toBe('Product not found');
+  });
+});

--- a/src/__test__/testSetup.ts
+++ b/src/__test__/testSetup.ts
@@ -83,7 +83,7 @@ export const getBuyerToken = async () => {
     name: 'Buyer',
     permissions: ['test-permission1', 'test-permission2'],
   };
-  const roleResponse = await request(app)
+  await request(app)
     .post('/api/v1/roles/create_role')
     .send(formData);
 
@@ -94,7 +94,7 @@ export const getBuyerToken = async () => {
     password: 'TestPassword123',
     userType: 'buyer',
   };
-  const res = await request(app).post('/api/v1/register').send(userData);
+  await request(app).post('/api/v1/register').send(userData);
 
   const updatedUser = await userRepository.findOne({
     where: { email: userData.email },

--- a/src/controller/buyerController.ts
+++ b/src/controller/buyerController.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from 'express';
+import dbConnection from '../database';
+import Product from '../database/models/productEntity';
+import errorHandler from '../middlewares/errorHandler';
+
+const productRepository = dbConnection.getRepository(Product);
+
+export const getOneProduct = errorHandler(
+  async (req: Request, res: Response) => {
+    const productId = parseInt(req.params.id);
+
+    const product = await productRepository.findOne({
+      where: { id: productId },
+      relations: ['category'],
+    });
+
+    if (!product) {
+      return res.status(404).json({ msg: 'Product not found' });
+    }
+
+    return res
+      .status(200)
+      .json({ msg: 'Product retrieved successfully', product });
+  }
+);

--- a/src/database/models/productEntity.ts
+++ b/src/database/models/productEntity.ts
@@ -50,7 +50,7 @@ export default class Product {
   @Column({ default: true })
   isAvailable: boolean;
 
-  @ManyToOne(() => UserModel)
+  @ManyToOne(() => UserModel, { onDelete: 'CASCADE' })
   vendor: UserModel;
 
   @CreateDateColumn()

--- a/src/docs/buyerDocs.ts
+++ b/src/docs/buyerDocs.ts
@@ -1,0 +1,22 @@
+/**
+ * @swagger
+ * /api/v1/buyer/get_product/{id}:
+ *   get:
+ *     summary: Get a specific product
+ *     tags: [Buyer]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         type: string
+ *         required: true
+ *         description: ID of the product to get
+ *     responses:
+ *       '200':
+ *         description: Successful
+ *       '404':
+ *         description: Product not found
+ *       '500':
+ *         description: Internal Server Error
+ */

--- a/src/routes/buyerRoutes.ts
+++ b/src/routes/buyerRoutes.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import { checkRole } from '../middlewares/authorize';
+import { getOneProduct } from '../controller/buyerController'
+import { IsLoggedIn } from '../middlewares/isLoggedIn';
+
+const buyerRouter = Router();
+
+buyerRouter.get(
+  '/get_product/:id',
+  IsLoggedIn,
+  checkRole(['Buyer']),
+  getOneProduct
+);
+
+export default buyerRouter;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,6 +3,7 @@ import userRouter from './userRoutes';
 import roleRoutes from './roleRoutes';
 import productRoutes from './productRoutes';
 import categoryRoutes from './categoryRoutes';
+import buyerRoutes from './buyerRoutes';
 
 const router = Router();
 
@@ -10,5 +11,6 @@ router.use('/user', userRouter);
 router.use('/roles', roleRoutes);
 router.use('/product', productRoutes);
 router.use('/category', categoryRoutes);
+router.use('/buyer', buyerRoutes);
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
Adds an endpoint where a buyer can retrieve a specific product

#### Description of Task to be completed?

- [x] Implement an API endpoint for retrieving a single product
- [x] Implement appropriate error handling and responses
- [x] Write comprehensive unit tests and documentation

#### How should this be manually tested?
- After cloning the repo, get a single product by accessing the api/v1/buyer/get_product/:id route and passing in the product id in the route parameters

#### Any background context you want to provide?
- This task depends on the manage product feature

####Screenshots
<img width="903" alt="swagger" src="https://github.com/atlp-rwanda/dynamites-ecomm-be/assets/109604986/b43dac8d-e086-47d7-bf3e-0787dac8a260">
<img width="600" alt="test 1" src="https://github.com/atlp-rwanda/dynamites-ecomm-be/assets/109604986/f00fe158-caf3-4811-a0df-a7ce5e45d483">
<img width="593" alt="test 2" src="https://github.com/atlp-rwanda/dynamites-ecomm-be/assets/109604986/c471c68f-1635-47d7-a7d0-a8cf9d351588">


#### What are the relevant pivotal trackers?
#54

