### PR TITLE
#119 Fix minor issue in stripe payment

### DIFF
--- a/src/__test__/payment.test.ts
+++ b/src/__test__/payment.test.ts
@@ -5,97 +5,118 @@ import { Order } from '../database/models/orderEntity';
 import dbConnection from '../database';
 import Stripe from 'stripe';
 
-
 jest.mock('stripe');
 const MockedStripe = Stripe as jest.Mocked<typeof Stripe>;
 
-
 describe('handlePayment', () => {
- let token: string;
- let order: Order;
+  let token: string;
+  let order: Order;
 
+  beforeAll(async () => {
+    await dbConnection.initialize();
+    await dbConnection.synchronize(true); // This will drop all tables
+    token = await getBuyerToken();
+    // Create a mock order in the database
+    const orderRepository = dbConnection.getRepository(Order);
+    order = orderRepository.create({
+      totalAmount: 100,
+      status: 'Pending',
+      trackingNumber: '123456',
+      paid: false,
+    });
+    await orderRepository.save(order);
+  });
 
- beforeAll(async () => {
-   await dbConnection.initialize();
-   await dbConnection.synchronize(true); // This will drop all tables
-   token = await getBuyerToken();
-   // Create a mock order in the database
-   const orderRepository = dbConnection.getRepository(Order);
-   order = orderRepository.create({
-     totalAmount: 100,
-     status: 'Pending',
-     trackingNumber: '123456',
-     paid: false,
-   });
-   await orderRepository.save(order);
- });
+  afterAll(async () => {
+    await dbConnection.close();
+  });
 
+  it('should process payment successfully', async () => {
+    const mockChargesCreate = jest.fn().mockResolvedValue({
+      id: 'charge_id',
+      amount: 10000,
+      currency: 'usd',
+      status: 'succeeded',
+    } as Stripe.Charge);
 
- afterAll(async () => {
-   await dbConnection.close();
- });
+    MockedStripe.prototype.charges = {
+      create: mockChargesCreate,
+    } as unknown as Stripe.ChargesResource;
 
+    const response = await request(app)
+      .post('/api/v1/buyer/payment')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ token: 'fake-token', orderId: order.id });
 
- it('should process payment successfully', async () => {
-   const mockChargesCreate = jest.fn().mockResolvedValue({
-     id: 'charge_id',
-     amount: 10000,
-     currency: 'usd',
-   } as Stripe.Charge);
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+    expect(response.body.paid).toBe(true);
+    expect(response.body.charge.id).toBe('charge_id');
+    expect(mockChargesCreate).toHaveBeenCalledWith({
+      amount: 10000,
+      currency: 'usd',
+      description: 'Test Charge',
+      source: 'fake-token',
+    });
+  });
 
+  it('should return 400 if payment is not successful', async () => {
+    // Set the order as not paid
+    const orderRepository = dbConnection.getRepository(Order);
+    order.paid = false;
+    await orderRepository.save(order);
 
-   MockedStripe.prototype.charges = {
-     create: mockChargesCreate,
-   } as unknown as Stripe.ChargesResource;
+    const mockChargesCreate = jest.fn().mockResolvedValue({
+      id: 'charge_id',
+      amount: 10000,
+      currency: 'usd',
+      status: 'failed',
+    } as Stripe.Charge);
 
+    MockedStripe.prototype.charges = {
+      create: mockChargesCreate,
+    } as unknown as Stripe.ChargesResource;
 
-   const response = await request(app)
-     .post('/api/v1/buyer/payment')
-     .set('Authorization', `Bearer ${token}`)
-     .send({ token: 'fake-token', orderId: order.id });
+    const response = await request(app)
+      .post('/api/v1/buyer/payment')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ token: 'fake-token', orderId: order.id });
 
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.paid).toBe(false);
+    expect(mockChargesCreate).toHaveBeenCalledWith({
+      amount: 10000,
+      currency: 'usd',
+      description: 'Test Charge',
+      source: 'fake-token',
+    });
+  });
 
-   expect(response.status).toBe(200);
-   expect(response.body.success).toBe(true);
-   expect(response.body.paid).toBe(true);
-   expect(response.body.charge.id).toBe('charge_id');
-   expect(mockChargesCreate).toHaveBeenCalledWith({
-     amount: 10000,
-     currency: 'usd',
-     description: 'Test Charge',
-     source: 'fake-token',
-   });
- });
+  it('should return 404 if order not found', async () => {
+    const response = await request(app)
+      .post('/api/v1/buyer/payment')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ token: 'fake-token', orderId: 999 });
 
+    expect(response.status).toBe(404);
+    expect(response.body.success).toBe(false);
+    expect(response.body.message).toBe('Order not found');
+  });
 
- it('should return 404 if order not found', async () => {
-   const response = await request(app)
-     .post('/api/v1/buyer/payment')
-     .set('Authorization', `Bearer ${token}`)
-     .send({ token: 'fake-token', orderId: 999 });
+  it('should return 400 if order already paid', async () => {
+    // Set the order as paid
+    const orderRepository = dbConnection.getRepository(Order);
+    order.paid = true;
+    await orderRepository.save(order);
 
+    const response = await request(app)
+      .post('/api/v1/buyer/payment')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ token: 'fake-token', orderId: order.id });
 
-   expect(response.status).toBe(404);
-   expect(response.body.success).toBe(false);
-   expect(response.body.message).toBe('Order not found');
- });
-
-
- it('should return 400 if order already paid', async () => {
-   // Set the order as paid
-   const orderRepository = dbConnection.getRepository(Order);
-   order.paid = true;
-   await orderRepository.save(order);
-
-
-   const response = await request(app)
-     .post('/api/v1/buyer/payment')
-     .set('Authorization', `Bearer ${token}`)
-     .send({ token: 'fake-token', orderId: order.id });
-
-
-   expect(response.status).toBe(400);
-   expect(response.body.success).toBe(false);
-   expect(response.body.message).toBe('Order has already been paid');
- });
+    expect(response.status).toBe(400);
+    expect(response.body.success).toBe(false);
+    expect(response.body.message).toBe('Order has already been paid');
+  });
 });

--- a/src/controller/buyerController.ts
+++ b/src/controller/buyerController.ts
@@ -64,12 +64,17 @@ export const getOneProduct = errorHandler(
       description: 'Test Charge',
       source: token,
     });
- 
- 
-    order.paid = true;
-    await orderRepository.save(order);
- 
-    return res.status(200).json({ success: true, paid: true, charge});
+
+    if (charge.status === 'succeeded') {
+      order.paid = true;
+      await orderRepository.save(order)
+
+      return res.status(200).json({ success: true, paid: true, charge});
+    }else{
+      return res
+      .status(400)
+      .json({ success: false, paid: false, message: `Charge status: ${charge.status}` });
+    }  
   }
  );
  


### PR DESCRIPTION
**what does this PR do?**
- checks the status of the stripe response object, and only changes order.paid to true when the status is succeeded, which implies that the payment is successful. Otherwise an error message is returned

**Description of the task to be completed**
- add status check before changing order.paid to true
-  add new tests to cover added lines

**What are the relevant pivotal trackers/story id?**
- #119 